### PR TITLE
Replaced switch statements with equivalent terse expressions

### DIFF
--- a/OptionalExtensions/Source/OptionalExtensions.swift
+++ b/OptionalExtensions/Source/OptionalExtensions.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2015 Rui Peres. All rights reserved.
 //
 
-import Foundation
 
 public extension Optional {
     

--- a/OptionalExtensions/Source/OptionalExtensions.swift
+++ b/OptionalExtensions/Source/OptionalExtensions.swift
@@ -12,44 +12,29 @@ public extension Optional {
     
     func filter(@noescape predicate: Wrapped -> Bool) -> Optional {
         
-        guard
-            let result = self.map (predicate)
-            where result == true
-            else { return .None }
-        
-        return self
+        return map(predicate) == .Some(true) ? self : .None
     }
     
     func replaceNil(with replacement: Wrapped) -> Optional {
         
-        switch self {
-        case .Some(_): return self
-        case .None: return .Some(replacement)
-        }
+        return self ?? replacement
     }
     
     func apply(@noescape f: Wrapped -> Void) {
         
-        switch self {
-        case .Some(let wrapped): f(wrapped)
-        default: break
-        }
+        if let wrapped = self { f(wrapped) }
     }
     
     func onSome(@noescape f: Wrapped -> Void) -> Optional {
         
-        switch self {
-        case .Some(let wrapped): f(wrapped); return .Some(wrapped)
-        case .None: return .None
-        }
+        apply(f)
+        return self
     }
     
     func onNone(@noescape f: Void -> Void) -> Optional {
         
-        switch self {
-        case .Some(let wrapped): return .Some(wrapped)
-        case .None: f(); return .None
-        }
+        if isNone { f() }
+        return self
     }
     
     var isSome: Bool {


### PR DESCRIPTION
Refactoring as discussed in `Sugary syntax version` #4
