### PR TITLE
Refactoring tests for better readability

### DIFF
--- a/OptionalExtensionsTests/OptionalExtensionsTests.swift
+++ b/OptionalExtensionsTests/OptionalExtensionsTests.swift
@@ -11,90 +11,193 @@ import OptionalExtensions
 
 class OptionalExtensionsTests: XCTestCase {
     
-    func testFilter() {
+    // MARK: - filter
+    
+    func test_filter_whenPredicateMatches_thenReturnsOptionalValue() {
+        // given
         let number: Int? = 3
         
-        let biggerThan2 = number.filter { $0 > 2 }
-        let biggerThan3 = number.filter { $0 > 3 }
+        // when
+        let result = number.filter { $0 > 2 }
         
-        XCTAssertTrue(biggerThan2 == .Some(3))
-        XCTAssertTrue(biggerThan3 == .None)
+        // then
+        XCTAssertEqual(result, 3)
     }
     
-    func testReplaceNil() {
+    func test_filter_whenPredicateDoesNotMatch_thenReturnsNil() {
+        // given
         let number: Int? = 3
-        let opt3 = number.replaceNil(with: 2)
-        XCTAssertTrue(opt3 == .Some(3))
         
+        // when
+        let result = number.filter { $0 > 3 }
+        
+        // then
+        XCTAssertNil(result)
+    }
+    
+    // MARK: - replaceNil
+    
+    func test_replaceNil_whenInvokedWithNonNil_thenReturnsOrginalValue() {
+        // given
+        let number: Int? = 3
+        
+        // when
+        let result = number.replaceNil(with: 2)
+        
+        // then
+        XCTAssertEqual(result, 3)
+    }
+    
+    func test_replaceNil_whenInvokedWithNil_thenReturnsReplacedValue() {
+        // given
         let nilledNumber: Int? = nil
-        let opt2 = nilledNumber.replaceNil(with: 2)
-        XCTAssertTrue(opt2 == .Some(2))
+        
+        // when
+        let result = nilledNumber.replaceNil(with: 2)
+        
+        // then
+        XCTAssertEqual(result, 2)
     }
     
-    func testApply() {
+    // MARK: - then
+    
+    func test_then_whenInvokedOnNonNilValue_thenOperationIsInvoked() {
+        // given
         var testInt = 0
-
-        let nilledNumber: Int? = nil
-        nilledNumber.then { testInt = $0 }
-        XCTAssertTrue(testInt == 0)
-
-        let number: Int? = 3
-        number.then { testInt = $0 }
-        XCTAssertTrue(testInt == 3)
+        let nonNilledNumber: Int? = 3
+        
+        // when
+        nonNilledNumber.then { _ in testInt = 2 }
+        
+        // then
+        XCTAssertEqual(testInt, 2)
     }
     
-    func testOnSome() {
+    func test_then_whenInvokedOnNilValue_thenOperationIsNotInvoked() {
+        // given
         var testInt = 0
-        
         let nilledNumber: Int? = nil
-        let sameNilledNumber = nilledNumber.onSome { print($0) }
-        XCTAssertTrue(testInt == 0)
-        XCTAssertTrue(sameNilledNumber == .None)
-
-        let number: Int? = 3
-        let sameNumber = number.onSome { testInt = $0 }
-        XCTAssertTrue(testInt == 3)
-        XCTAssertTrue(sameNumber == .Some(3))
+        
+        // when
+        nilledNumber.then { _ in testInt = 2 }
+        
+        // then
+        XCTAssertEqual(testInt, 0)
     }
     
-    func testOnNone() {
+    // MARK: - onSome
+    
+    func test_onSome_whenInvokedOnNonNilValue_thenOperationIsInvoked_andValueIsReturned() {
+        // given
         var testInt = 0
+        let nonNilledNumber: Int? = 3
         
-        let number: Int? = 3
-        let sameNumber = number.onNone { testInt = 99 }
-        XCTAssertTrue(testInt == 0)
-        XCTAssertTrue(sameNumber == .Some(3))
+        // when
+        let result = nonNilledNumber.onSome { _ in testInt = 2 }
         
-        let nilledNumber: Int? = nil
-        let sameNilledNumber = nilledNumber.onNone { testInt = 99 }
-        XCTAssertTrue(testInt == 99)
-        XCTAssertTrue(sameNilledNumber == .None)
+        // then
+        XCTAssertEqual(testInt, 2)
+        XCTAssertEqual(result, 3)
     }
     
-    func testIsSome() {
+    func test_onSome_whenInvokedOnNilValue_thenOperationIsNotInvoked_andNilIsReturned() {
+        // given
+        var testInt = 0
+        let nilledNumber: Int? = nil
+        
+        // when
+        let result = nilledNumber.onSome { _ in testInt = 2 }
+        
+        // then
+        XCTAssertEqual(testInt, 0)
+        XCTAssertNil(result)
+    }
+    
+    // MARK: - onNone
+    
+    func test_onSome_whenInvokedOnNonNilValue_thenOperationIsNotInvoked_andValueIsReturned() {
+        // given
+        var testInt = 0
+        let nonNilledNumber: Int? = 3
+        
+        // when
+        let result = nonNilledNumber.onNone { _ in testInt = 2 }
+        
+        // then
+        XCTAssertEqual(testInt, 0)
+        XCTAssertEqual(result, 3)
+    }
+    
+    func test_onSome_whenInvokedOnNilValue_thenOperationIsInvoked_andNilIsReturned() {
+        // given
+        var testInt = 0
+        let nilledNumber: Int? = nil
+        
+        // when
+        let result = nilledNumber.onNone { _ in testInt = 2 }
+        
+        // then
+        XCTAssertEqual(testInt, 2)
+        XCTAssertNil(result)
+    }
+    
+    // MARK: - isSome
+    
+    func test_isSome_whenInvokedOnNonNilValue_thenReturnsTrue() {
+        // given
         let number: Int? = 3
+        
+        // then
         XCTAssertTrue(number.isSome)
-        
+    }
+    
+    func test_isSome_whenInvokedOnNilValue_thenReturnsFalse() {
+        // given
         let nilledNumber: Int? = nil
+        
+        // then
         XCTAssertFalse(nilledNumber.isSome)
     }
     
-    func testIsNone() {
+    // MARK: - isNone
+    
+    func test_isNone_whenInvokedOnNonNilValue_thenReturnsFalse() {
+        // given
         let number: Int? = 3
-        XCTAssertFalse(number.isNone)
         
+        // then
+        XCTAssertFalse(number.isNone)
+    }
+    
+    func test_isNone_whenInvokedOnNilValue_thenReturnsTrue() {
+        // given
         let nilledNumber: Int? = nil
+        
+        // then
         XCTAssertTrue(nilledNumber.isNone)
     }
     
-    func testMaybe() {
+    // MARK: - maybe
+    
+    func test_maybe_whenInvokedOnNonNilValue_withNonNilPredicate_thenExecutesOperationAndReturnsItsResult() {
+        // given
+        let nonNilledNumber: Int? = 1
         
-        let number: Int? = 3
-        let value = number.maybe(100) { $0 + 1 }
-        XCTAssertEqual(value, 4)
+        // when
+        let result = nonNilledNumber.maybe(100) { $0 + 50 }
         
+        // then
+        XCTAssertEqual(result, 51)
+    }
+    
+    func test_maybe_whenInvokedOnNilValue_withNilPredicate_thenDoesNotExecuteOperationAndReturnsPredicate() {
+        // given
         let nilledNumber: Int? = nil
-        let value1 = nilledNumber.maybe(100) { $0 + 1 }
-        XCTAssertEqual(value1, 100)
+        
+        // when
+        let result = nilledNumber.maybe(100) { $0 + 50 }
+        
+        // then
+        XCTAssertEqual(result, 100)
     }
 }

--- a/OptionalExtensionsTests/OptionalExtensionsTests.swift
+++ b/OptionalExtensionsTests/OptionalExtensionsTests.swift
@@ -39,10 +39,10 @@ class OptionalExtensionsTests: XCTestCase {
     
     func test_replaceNil_whenInvokedWithNonNil_thenReturnsOriginalValue() {
         // given
-        let number: Int? = 3
+        let nonNilledNumber: Int? = 3
         
         // when
-        let result = number.replaceNil(with: 2)
+        let result = nonNilledNumber.replaceNil(with: 2)
         
         // then
         XCTAssertEqual(result, 3)
@@ -145,10 +145,10 @@ class OptionalExtensionsTests: XCTestCase {
     
     func test_isSome_whenInvokedOnNonNilValue_thenReturnsTrue() {
         // given
-        let number: Int? = 3
+        let nonNilledNumber: Int? = 3
         
         // then
-        XCTAssertTrue(number.isSome)
+        XCTAssertTrue(nonNilledNumber.isSome)
     }
     
     func test_isSome_whenInvokedOnNilValue_thenReturnsFalse() {
@@ -163,10 +163,10 @@ class OptionalExtensionsTests: XCTestCase {
     
     func test_isNone_whenInvokedOnNonNilValue_thenReturnsFalse() {
         // given
-        let number: Int? = 3
+        let nonNilledNumber: Int? = 3
         
         // then
-        XCTAssertFalse(number.isNone)
+        XCTAssertFalse(nonNilledNumber.isNone)
     }
     
     func test_isNone_whenInvokedOnNilValue_thenReturnsTrue() {

--- a/OptionalExtensionsTests/OptionalExtensionsTests.swift
+++ b/OptionalExtensionsTests/OptionalExtensionsTests.swift
@@ -37,7 +37,7 @@ class OptionalExtensionsTests: XCTestCase {
     
     // MARK: - replaceNil
     
-    func test_replaceNil_whenInvokedWithNonNil_thenReturnsOrginalValue() {
+    func test_replaceNil_whenInvokedWithNonNil_thenReturnsOriginalValue() {
         // given
         let number: Int? = 3
         
@@ -87,7 +87,7 @@ class OptionalExtensionsTests: XCTestCase {
     
     // MARK: - onSome
     
-    func test_onSome_whenInvokedOnNonNilValue_thenOperationIsInvoked_andValueIsReturned() {
+    func test_onSome_whenInvokedOnNonNilValue_thenOperationIsInvoked_andOperationResultIsReturned() {
         // given
         var testInt = 0
         let nonNilledNumber: Int? = 3
@@ -115,7 +115,7 @@ class OptionalExtensionsTests: XCTestCase {
     
     // MARK: - onNone
     
-    func test_onNone_whenInvokedOnNonNilValue_thenOperationIsNotInvoked_andValueIsReturned() {
+    func test_onNone_whenInvokedOnNonNilValue_thenOperationIsNotInvoked_andOperationResultIsReturned() {
         // given
         var testInt = 0
         let nonNilledNumber: Int? = 3
@@ -179,7 +179,7 @@ class OptionalExtensionsTests: XCTestCase {
     
     // MARK: - maybe
     
-    func test_maybe_whenInvokedOnNonNilValue_withNonNilPredicate_thenExecutesOperationAndReturnsItsResult() {
+    func test_maybe_whenInvokedOnNonNilValue_thenExecutesOperationAndReturnsItsResult() {
         // given
         let nonNilledNumber: Int? = 1
         
@@ -190,7 +190,7 @@ class OptionalExtensionsTests: XCTestCase {
         XCTAssertEqual(result, 51)
     }
     
-    func test_maybe_whenInvokedOnNilValue_withNilPredicate_thenDoesNotExecuteOperationAndReturnsPredicate() {
+    func test_maybe_whenInvokedOnNilValue_thenDoesNotExecuteOperationAndReturnsDefaultValue() {
         // given
         let nilledNumber: Int? = nil
         

--- a/OptionalExtensionsTests/OptionalExtensionsTests.swift
+++ b/OptionalExtensionsTests/OptionalExtensionsTests.swift
@@ -115,7 +115,7 @@ class OptionalExtensionsTests: XCTestCase {
     
     // MARK: - onNone
     
-    func test_onSome_whenInvokedOnNonNilValue_thenOperationIsNotInvoked_andValueIsReturned() {
+    func test_onNone_whenInvokedOnNonNilValue_thenOperationIsNotInvoked_andValueIsReturned() {
         // given
         var testInt = 0
         let nonNilledNumber: Int? = 3
@@ -128,7 +128,7 @@ class OptionalExtensionsTests: XCTestCase {
         XCTAssertEqual(result, 3)
     }
     
-    func test_onSome_whenInvokedOnNilValue_thenOperationIsInvoked_andNilIsReturned() {
+    func test_onNone_whenInvokedOnNilValue_thenOperationIsInvoked_andNilIsReturned() {
         // given
         var testInt = 0
         let nilledNumber: Int? = nil


### PR DESCRIPTION
I use tests as to understand what a project does - this is a refactor to make that understanding easier.

Using the given / when / then naming convention, as well as (when possible) one assert per test.

After doing this refactor, reading over the tests gives me a good idea of what the extensions do. (and on that note I'm wondering if "maybe" expresses what it does... but yet to find a better name):

![screen shot 2016-01-12 at 11 08 37](https://cloud.githubusercontent.com/assets/1094502/12262057/3babb244-b91d-11e5-89ed-85c3ceb09130.png)
