### PR TITLE
Lower deployment requirements

### DIFF
--- a/OptionalExtensions.podspec
+++ b/OptionalExtensions.podspec
@@ -12,7 +12,10 @@ Pod::Spec.new do |s|
     s.social_media_url = "https://twitter.com/peres"
     s.source           = { :git => "https://github.com/RuiAAPeres/OptionalExtensions.git", :tag => s.version.to_s }
 
-    s.ios.deployment_target = "9.0"
+    s.ios.deployment_target = "8.0"
+    s.osx.deployment_target = "10.10"
+    s.tvos.deployment_target = "9.0"
+    s.watchos.deployment_target = "2.0"
 
     s.source_files  = "OptionalExtensions/Source/*"
 end

--- a/OptionalExtensions.xcodeproj/project.pbxproj
+++ b/OptionalExtensions.xcodeproj/project.pbxproj
@@ -588,7 +588,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.1;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -608,7 +608,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.1;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -627,7 +627,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.1;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
@@ -646,7 +646,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.1;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};
@@ -662,7 +662,7 @@
 				INFOPLIST_FILE = OptionalExtensions/Support/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "rp.OptionalExtensions-Mac";
 				PRODUCT_NAME = OptionalExtensions;
 				SDKROOT = macosx;
@@ -682,7 +682,7 @@
 				INFOPLIST_FILE = OptionalExtensions/Support/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "rp.OptionalExtensions-Mac";
 				PRODUCT_NAME = OptionalExtensions;
 				SDKROOT = macosx;


### PR DESCRIPTION
Hey!

Optional extensions look great, thank you for them!

This PR lowers deployment targets to following:
- iOS 8
- OS X 10.10
- tvOS 9.0
- watchOS 2.0

There does not seem any particular reason not to support those.
